### PR TITLE
Use mkdir -p

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -121,7 +121,7 @@ fi
 
 # build a startup script
 echo -n "-----> Creating startup script... "
-mkdir "$build_dir/bin"
+mkdir -p "$build_dir/bin"
 cat <<EOF >"$build_dir/bin/start_nginx"
 #!/usr/bin/env bash
 erb conf/nginx.conf.erb > conf/nginx.conf


### PR DESCRIPTION
All the other `mkdir` commands in the script use the `-p` flag to prevent errors.
